### PR TITLE
Set EZ_PATH and PATH in correct shell configuration file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,24 @@ PROFILE="$USER_HOME/.bashrc" # default
 if [ "$(uname)" = "Linux" ]; then
 
   #Linux case
-  PROFILE="$USER_HOME/.bashrc"
+  # Check which sheel the user is using
+  # Trim the $SHELL variable to only have the shell name
+  SHELL_NAME=`echo $SHELL | awk -F/ '{print $NF}'`
+
+  case "$SHELL_NAME" in
+    "sh" )
+      PROFILE="$USER_HOME/.profile" ;;
+    "bash" )
+      PROFILE="$USER_HOME/.bashrc" ;;
+    "zsh" )
+      PROFILE="$USER_HOME/.zshrc" ;;
+    "csh" )
+      PROFILE="$USER_HOME/.cshrc" ;;
+    "tcsh" )
+      PROFILE="$USER_HOME/.tcshrc" ;;
+    "ksh" )
+      PROFILE="$USER_HOME/.kshrc" ;;
+  esac
 
 else
 


### PR DESCRIPTION
The install.sh script does not take the user shell in account and will always set the EZ_PATH and PATH variables in the .bashrc file, which is only read by bash. Non-bash users have to manually set the variables in order to use EASEA.

The install script need to check for the user shell and edit the right configuration file.
