### PR TITLE
Default seed should be generated from robust source

### DIFF
--- a/libeasea/CEvolutionaryAlgorithm.cpp
+++ b/libeasea/CEvolutionaryAlgorithm.cpp
@@ -296,8 +296,8 @@ params->parentReduction = 1;
     else{
 	
 	/* Logging out the results */
-	LOG_MSG(msgType::INFO, "Seed: %d", params->seed);
-	LOG_MSG(msgType::INFO, "Best fitness: %ld", static_cast<long>(population->Best->getFitness()));
+	LOG_MSG(msgType::INFO, "Seed: %u", params->seed);
+	LOG_MSG(msgType::INFO, "Best fitness: %g", population->Best->getFitness());
 	LOG_MSG(msgType::INFO, "Elapsed time: %f", elapsed_seconds.count());
     }
 

--- a/libeasea/COptionParser.cpp
+++ b/libeasea/COptionParser.cpp
@@ -46,7 +46,7 @@ void parseArguments(const char* parametersFileName, int ac, char** av, std::uniq
     options.add_options()
         ("help,h", "produce help message")
 	("version,v", "Print version")
-        ("seed,s", po::value<int>(), "set the global seed of the pseudo random generator")
+        ("seed,s", po::value<unsigned>(), "set the global seed of the pseudo random generator")
         ("popSize,p", po::value<int>(), "set the population size")
         ("nbOffspring", po::value<float>(), "set the offspring population size")
         ("survivingParents", po::value<float>(), "set the reduction size for parent population")

--- a/libeasea/Parameters.cpp
+++ b/libeasea/Parameters.cpp
@@ -10,6 +10,7 @@
 #include "CRandomGenerator.h"
 #include <stdio.h>
 #include <cmath>
+#include <random>
 
 extern CRandomGenerator* globalRandomGenerator;
 
@@ -24,7 +25,7 @@ Parameters::Parameters(std::string const& filename, int argc, char* argv[]) : op
 	silentNetwork = setVariable("silentNetwork", false);
 	alwaysEvaluate = setVariable("alwaysEvaluate", false);
 
-	seed = setVariable("seed", 0);
+	seed = setVariable("seed", std::random_device{}()); // use hardware based entropy as seed
 	globGen = decltype(globGen){static_cast<unsigned int>(seed)};
 	globalRandomGenerator = &globGen;
 	randomGenerator = globalRandomGenerator;

--- a/libeasea/Parameters.cpp
+++ b/libeasea/Parameters.cpp
@@ -26,7 +26,7 @@ Parameters::Parameters(std::string const& filename, int argc, char* argv[]) : op
 	alwaysEvaluate = setVariable("alwaysEvaluate", false);
 
 	seed = setVariable("seed", std::random_device{}()); // use hardware based entropy as seed
-	globGen = decltype(globGen){static_cast<unsigned int>(seed)};
+	globGen = decltype(globGen){seed};
 	globalRandomGenerator = &globGen;
 	randomGenerator = globalRandomGenerator;
 

--- a/libeasea/include/Parameters.h
+++ b/libeasea/include/Parameters.h
@@ -52,7 +52,7 @@ class Parameters {
     float pMutationPerGene;
     CRandomGenerator* randomGenerator;
 
-    int seed;
+    unsigned int seed;
 
     unsigned int parentPopulationSize;
     unsigned int offspringPopulationSize;


### PR DESCRIPTION
- The default seed is now generated from a robust hardware source.
- Fix runs having the same seed if they were launched at the same second.

fix #74 